### PR TITLE
Publish forked documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,28 @@ cd docs
 mvn package -Dmaven.test.skip
 ```
 
+(The commands above have been tested with OpenJDK 11)
+
 A gh-pages deployable will be generated at **docs/target/docbook/index**. This fork publishes the generated site onto 
 [gh-pages branch under root directory](https://github.com/QubitPi/jersey/tree/gh-pages)
+
+Syncing with [upstream](https://github.com/eclipse-ee4j/jersey)
+---------------------------------------------------------------
+
+This fork has two branches
+
+1. *gh-pages* branch that exclusively host the generated static site
+2. *origin/master* branch which is the default branch of this fork. The syncing we are talking about here happens
+   between this branch and upstream/master
+
+We use a rebase-style sync:
+
+```bash
+git checkout master
+git fetch upstream
+git rebase upstream/master
+git push origin master -f
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@
 [//]: # "  "
 [//]: # " SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 "
 
+Deploying [jersey (fork)](https://github.com/QubitPi/jersey) to GitHub Pages
+============================================================================
+
+Building the documentation site involves **docs** sub-module only in this Maven project:
+
+```bash
+cd docs
+mvn package -Dmaven.test.skip
+```
+
+A gh-pages deployable will be generated at **docs/target/docbook/index**. This fork publishes the generated site onto 
+[gh-pages branch under root directory](https://github.com/QubitPi/jersey/tree/gh-pages)
+
+---
+
 [![Build Status](https://travis-ci.org/eclipse-ee4j/jersey.svg?branch=master)](https://travis-ci.org/eclipse-ee4j/jersey)
 &nbsp;[![EPL-2.0](./etc/epl.svg)](https://www.eclipse.org/legal/epl-2.0/)
 &nbsp;[![GPL+CPE-2.0](./etc/gpl.svg)](https://www.gnu.org/software/classpath/license.html)

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -94,7 +94,7 @@
                     <calloutsExtension>true</calloutsExtension>
                     <highlightDefaultLanguage />
                     <highlightSource>true</highlightSource>
-                    <htmlStylesheet>/jersey.github.io/documentation.css</htmlStylesheet>
+                    <htmlStylesheet>https://eclipse-ee4j.github.io/jersey.github.io/documentation.css</htmlStylesheet>
                     <!--<htmlStylesheet>https://jersey.java.net/documentation.css</htmlStylesheet>-->
                     <linenumberingExtension>true</linenumberingExtension>
                     <linenumberingEveryNth>1</linenumberingEveryNth>


### PR DESCRIPTION
Changelog
---------

### Added

- Documented how to generate [project website](https://qubitpi.github.io/jersey/) locally
- Documented how to sync with upstream

### Changed

- Fetched CSS stylesheet directly from a eclipse resource URL, instead of a relative local (eclipse) server path.

### Deprecated

### Removed

### Fixed

### Security
